### PR TITLE
Fix强制转换Object为array时，对象中的数字属性无法读取问题

### DIFF
--- a/mock/index.php
+++ b/mock/index.php
@@ -13,7 +13,7 @@ function __object_array($e){
     }
     return $e;
 }
-$__settings = __object_array(json_decode($_POST['_fms']));
+$__settings = __object_array(json_decode($_POST['_fms'], true));
 
 /*
     template            "news.php"


### PR DESCRIPTION
PHP对象强制转换为array时，对象中的数字属性转化为数组后将无法读取，例如构造两个数组$ids = [1,2,3];$idTypes=[‘1’ => ‘a’, ‘2’ => ‘b’, ‘3’ => ‘c’];但是模板输出$idTypes[$ids[0]]时报错“Notice: Undefined offset: 1 in ………” 。可以用json_decode($str, true)自行转换数组比较好。 个人测试例子：http://www.histriver.com/php/801